### PR TITLE
Add outputName so dotnet cli will find the package.

### DIFF
--- a/src/dotnet-forge/project.json
+++ b/src/dotnet-forge/project.json
@@ -2,7 +2,8 @@
   "version": "1.0.0-*",
   "buildOptions": {
     "debugType": "portable",
-    "emitEntryPoint": true
+    "emitEntryPoint": true,
+    "outputName": "dotnet-forge"
   },
   "dependencies": {},
   "frameworks": {


### PR DESCRIPTION
This is what lets the cli know the dotnet package is available for the cli tool to invoke. 

[source](http://www.elanderson.net/2016/06/net-cli-custom-tool/)
